### PR TITLE
PRG: handle entry address if the header contains a 0x0a byte.

### DIFF
--- a/dis.pl
+++ b/dis.pl
@@ -554,7 +554,7 @@ sub xex {
 sub prg {
     my ($mem, $opts) = @_;
     my $start = unpack "v", substr $mem, 0, 2;
-    if ($mem =~ /^......\x9E *(\d+)/) {
+    if ($mem =~ /^......\x9E *(\d+)/s) {
         push @{$opts->{entry}}, sprintf "%X", $1;
     }
     printf "    opt h-\n";


### PR DESCRIPTION
By default the dot metacharacter doesn't match a newline.
